### PR TITLE
Improve hint path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-  DOTNET_VERSION: 7.0.x
+  DOTNET_VERSION: 8.0.x
 
 jobs:
   build:

--- a/src/ScribanSourceGenerator/ScribanSourceGenerator.cs
+++ b/src/ScribanSourceGenerator/ScribanSourceGenerator.cs
@@ -28,7 +28,7 @@ public class ScribanSourceGenerator : IIncrementalGenerator
             var buffer = new StringBuilder();
 
             context.AddSource(
-                SyntaxNodeHelper.AppendName(buffer, t.Type),
+                SyntaxNodeHelper.GetHintPath(t.Type, buffer),
                 Source(render(t, buffer))
                 );
         });

--- a/src/ScribanSourceGenerator/ScribanSourceGenerator.csproj
+++ b/src/ScribanSourceGenerator/ScribanSourceGenerator.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -20,11 +20,12 @@
     <Authors>Nobuyuki Iwanaga</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Scriban" Version="5.10.0" IncludeAssets="build" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" PrivateAssets="all" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" PrivateAssets="all" />

--- a/src/ScribanSourceGenerator/ScribanSourceGenerator.csproj
+++ b/src/ScribanSourceGenerator/ScribanSourceGenerator.csproj
@@ -23,9 +23,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Scriban" Version="5.5.0" IncludeAssets="Build" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
+    <PackageReference Include="Scriban" Version="5.10.0" IncludeAssets="build" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" PrivateAssets="all" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" PrivateAssets="all" />
   </ItemGroup>
@@ -34,9 +34,7 @@
   https://www.meziantou.net/packaging-a-roslyn-analyzer-with-nuget-dependencies.htm
   -->
   <Target Name="AddNuGetDlls" BeforeTargets="_GetPackageFiles">
-    <JoinItems Left="@(ResolvedCompileFileDefinitions)" LeftKey="NuGetPackageId" LeftMetadata="*"
-               Right="@(PackageReference)" RightKey="" RightMetadata="*"
-               ItemSpecToUse="Left">
+    <JoinItems Left="@(ResolvedCompileFileDefinitions)" LeftKey="NuGetPackageId" LeftMetadata="*" Right="@(PackageReference)" RightKey="" RightMetadata="*" ItemSpecToUse="Left">
       <Output TaskParameter="JoinResult" ItemName="_PackagesToPack" />
     </JoinItems>
 


### PR DESCRIPTION
The previous method used line numbers, so editing code prior to the class would have changed the hint path.
The new method uses the index in Members.
Moreover, since Roslyn has been updated to allow the use of `/` and `\`, the hint path is based on the full path of the original source.

if you have the following code in `C:/a/b/c.cs`

```cs
namespace N;

[ScribanSourceGenerator.ClassMember("")]
public partial class A;
```

The hint path with the previous method is: `N_A[a]3.cs`
That with the new method is: `scriban/a/b/c-0.cs`

Then, if you change the code to the folloing

```cs
namespace N;

// comment
[ScribanSourceGenerator.ClassMember("""


""")]
public partial class A;
```

The previous is changed to `N_A[a]7.cs` while the new is unchanged.
